### PR TITLE
Bugfix: Replace @flatten-js/boolean-op dependency with newest version of @flatten-js/core.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatten-js/polygon-offset",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1123,19 +1123,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@flatten-js/boolean-op/-/boolean-op-1.1.1.tgz",
       "integrity": "sha512-GQYkT0+HuyG/Lvt6F99G/emuTWbilCq2n8l9Kkgb5ICIrKG4b2Amjo49UEaS5XxcQ8pfoDwZvXRONui7gagRrQ=="
-    },
-    "@flatten-js/core": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@flatten-js/core/-/core-1.0.14.tgz",
-      "integrity": "sha512-5DWp7CdLLtmpn98t/fQqz3Dmz6H4D95dBDcWrajuqGZ3ObjHQVkQ1+0ihDBE6l0Ygx+Luw69nE0ivc9Q8DYJFQ==",
-      "requires": {
-        "@flatten-js/interval-tree": "^1.0.5"
-      }
-    },
-    "@flatten-js/interval-tree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@flatten-js/interval-tree/-/interval-tree-1.0.6.tgz",
-      "integrity": "sha512-BTI9AwaiJdh+Ewt3XjgwSeb0Un0OoULOUTHE4Fo93SYYgVo5PGzqD047rFVW4GhI7j9iDCbHq4B4VWyqDlarDw=="
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -2362,7 +2349,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2383,12 +2371,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2403,17 +2393,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2530,7 +2523,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2542,6 +2536,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2556,6 +2551,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2563,12 +2559,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2587,6 +2585,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2667,7 +2666,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2679,6 +2679,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2764,7 +2765,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2800,6 +2802,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2819,6 +2822,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2862,12 +2866,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4042,6 +4048,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -5443,7 +5450,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,8 @@
   "engines": {
     "node": ">=4.2.4"
   },
-  "dependencies": {
-    "@flatten-js/boolean-op": "^1.1.1"
-  },
   "peerDependencies": {
-    "@flatten-js/core": "^1.0.15"
+    "@flatten-js/core": "^1.2.15"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/polygonOffset.js
+++ b/src/polygonOffset.js
@@ -6,11 +6,7 @@
 import {Segment, Arc, Polygon, Face} from "@flatten-js/core";
 import {CW, CCW, INSIDE, OUTSIDE, ORIENTATION} from "@flatten-js/core";
 import {vector} from "@flatten-js/core";
-import {unify,subtract} from "@flatten-js/boolean-op";
-import  {BOOLEAN_UNION} from "@flatten-js/boolean-op";
-
-import {addToIntPoints, getSortedArray, splitByIntersections} from "@flatten-js/boolean-op";
-import {removeNotRelevantChains, removeOldFaces, restoreFaces} from "@flatten-js/boolean-op";
+import {BooleanOperations} from "@flatten-js/core";
 
 import {arcSE, arcStartSweep, arcEndSweep} from "./createArcs";
 
@@ -45,10 +41,10 @@ export function offset(polygon, value) {
             }
 
             if (w > 0) {
-                offsetPolygon = unify(offsetPolygon, offsetEdge);
+                offsetPolygon = BooleanOperations.unify(offsetPolygon, offsetEdge);
             }
             else {
-                offsetPolygon = subtract(offsetPolygon, offsetEdge);
+                offsetPolygon = BooleanOperations.subtract(offsetPolygon, offsetEdge);
             }
         }
     }
@@ -98,13 +94,13 @@ export function offsetArc(arc, value) {
     edge_cap2 = [...polygon.edges][3];
 
     for (let pt of ips) {
-        addToIntPoints(edge_cap1, pt, int_points);
-        addToIntPoints(edge_cap2, pt, int_points);
+        BooleanOperations.addToIntPoints(edge_cap1, pt, int_points);
+        BooleanOperations.addToIntPoints(edge_cap2, pt, int_points);
     }
 
     // Sort intersection points and insert them as new vertices
-    let int_points_sorted = getSortedArray(int_points);
-    splitByIntersections(polygon, int_points_sorted);
+    let int_points_sorted = BooleanOperations.getSortedArray(int_points);
+    BooleanOperations.splitByIntersections(polygon, int_points_sorted);
 
 
     // Set BV flags
@@ -116,8 +112,8 @@ export function offsetArc(arc, value) {
     }
 
     // Remove inner "chains"
-    let op = BOOLEAN_UNION;
-    removeNotRelevantChains(polygon, op, int_points_sorted, true);
+    let op = BooleanOperations.BOOLEAN_UNION;
+    BooleanOperations.removeNotRelevantChains(polygon, op, int_points_sorted, true);
 
     // return int_points_sorted;
     // Swap links
@@ -148,9 +144,9 @@ export function offsetArc(arc, value) {
         }
 
         // remove old faces
-        removeOldFaces(polygon, int_points);
+        BooleanOperations.removeOldFaces(polygon, int_points);
         // restore faces
-        restoreFaces(polygon, int_points, int_points);
+        BooleanOperations.restoreFaces(polygon, int_points, int_points);
     }
 
     let face0 = [...polygon.faces][0];


### PR DESCRIPTION
Boolean-op is deprecated and doesn't work with the newest version of core anymore. Core now contains all necessary boolean operations.